### PR TITLE
Add circleci for continous deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,6 @@ jobs:
             . venv/bin/activate
             sudo apt update
             pip install -r requirements.txt
-            pip install -r requirements_dev.txt
 
       - run:
           name: enforce styleguide

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,24 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/python:3.7.5
+
+    working_directory: ~/ner-project
+
+    steps:
+      - checkout
+      - run:
+          name: install dependencies
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            sudo apt update
+            pip install -r requirements.txt
+            pip install -r requirements_dev.txt
+
+      - run:
+          name: enforce styleguide
+          command: |
+            . venv/bin/activate
+            flake8 ner

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.38.1
+flake8==3.7.8
 pandas==0.23.4
 pre-commit==1.18.2
 psycopg2==2.8.4

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,2 +1,1 @@
 pre-commit==1.18.2
-python-dotenv==0.10.3


### PR DESCRIPTION
**Steps missing from yml file**
- running tests (easiest way would be calling `pytest`) -- we don't actually have any tests
- deployment instructions (e.g. pushing docker image and building container to the cloud)