### PR TITLE
Install Spacy language model in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ WORKDIR /usr/src/ner
 COPY requirements.txt .
 RUN pip3 install -r requirements.txt
 
+RUN python3 -m spacy download en
+
 COPY . .
 
 EXPOSE 5000

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ pandas==0.23.4
 pre-commit==1.18.2
 psycopg2==2.8.4
 python-dotenv==0.10.3
+spacy==2.2.4
 SQLAlchemy==1.2.15
 uvicorn==0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.38.1
 pandas==0.23.4
 pre-commit==1.18.2
-psycopg2==2.8.4
+psycopg2-binary==2.8.4
 python-dotenv==0.10.3
 spacy==2.2.4
 SQLAlchemy==1.2.15


### PR DESCRIPTION
Feel free to change the Spacy version if this is not the one you are using. This installs the `en` model for Spacy. Also changed installation for psycopg through the binary compilation.